### PR TITLE
Add method to create a virtual desktop

### DIFF
--- a/pyvda/com_defns.py
+++ b/pyvda/com_defns.py
@@ -203,7 +203,7 @@ class IVirtualDesktopManagerInternal(IUnknown):
                 POINTER(IVirtualDesktop), AdjacentDesktop, POINTER(POINTER(IVirtualDesktop)),
             )),
             STDMETHOD(HRESULT, "SwitchDesktop", (HWND, POINTER(IVirtualDesktop),)),
-            STDMETHOD(HRESULT, "CreateDesktopW", (HWND, POINTER(POINTER(IVirtualDesktop)),)),
+            COMMETHOD([], HRESULT, "CreateDesktopW", (["in"], HWND, "hwnd"), (["out"], POINTER(POINTER(IVirtualDesktop)), "pDesktop"),),
             STDMETHOD(HRESULT, "MoveDesktop", (POINTER(IVirtualDesktop), HWND, INT)),
             STDMETHOD(HRESULT, "RemoveDesktop", (POINTER(IVirtualDesktop), POINTER(IVirtualDesktop))),
             # Since build 10240
@@ -223,7 +223,7 @@ class IVirtualDesktopManagerInternal(IUnknown):
                 POINTER(IVirtualDesktop), AdjacentDesktop, POINTER(POINTER(IVirtualDesktop)),
             )),
             STDMETHOD(HRESULT, "SwitchDesktop", (HWND, POINTER(IVirtualDesktop),)),
-            STDMETHOD(HRESULT, "CreateDesktopW", (HWND, POINTER(POINTER(IVirtualDesktop)),)),
+            COMMETHOD([], HRESULT, "CreateDesktopW", (["in"], HWND, "hwnd"), (["out"], POINTER(POINTER(IVirtualDesktop)), "pDesktop"),),
             STDMETHOD(HRESULT, "RemoveDesktop", (POINTER(IVirtualDesktop), POINTER(IVirtualDesktop))),
             # Since build 10240
             COMMETHOD([], HRESULT, "FindDesktop",
@@ -242,7 +242,7 @@ class IVirtualDesktopManagerInternal(IUnknown):
                 POINTER(IVirtualDesktop), AdjacentDesktop, POINTER(POINTER(IVirtualDesktop)),
             )),
             STDMETHOD(HRESULT, "SwitchDesktop", (POINTER(IVirtualDesktop),)),
-            STDMETHOD(HRESULT, "CreateDesktopW", (POINTER(POINTER(IVirtualDesktop)),)),
+            COMMETHOD([], HRESULT, "CreateDesktopW", (["out"], POINTER(POINTER(IVirtualDesktop)), "pDesktop"),),
             STDMETHOD(HRESULT, "RemoveDesktop", (POINTER(IVirtualDesktop), POINTER(IVirtualDesktop))),
             # Since build 10240
             COMMETHOD([], HRESULT, "FindDesktop",

--- a/pyvda/pyvda.py
+++ b/pyvda/pyvda.py
@@ -303,6 +303,17 @@ class VirtualDesktop():
         """
         return cls(current=True)
 
+    @classmethod
+    def create(cls):
+        """Create a new virtual desktop.
+
+        Returns:
+            VirtualDesktop: The created desktop.
+        """
+
+        _manager_internal = get_vd_manager_internal()
+
+        return cls(desktop=_manager_internal.CreateDesktopW())
 
     @property
     def id(self) -> GUID:

--- a/pyvda/pyvda.py
+++ b/pyvda/pyvda.py
@@ -311,9 +311,14 @@ class VirtualDesktop():
             VirtualDesktop: The created desktop.
         """
 
-        _manager_internal = get_vd_manager_internal()
+        manager_internal = get_vd_manager_internal()
 
-        return cls(desktop=_manager_internal.CreateDesktopW())
+        if BUILD_OVER_20231:
+            desktop = manager_internal.CreateDesktopW(NULL_PTR)
+        else:
+            desktop = manager_internal.CreateDesktopW()
+
+        return cls(desktop=desktop)
 
     @property
     def id(self) -> GUID:


### PR DESCRIPTION
Adds the `VirtualDesktop.create()` method to allow the creation of a new virtual desktop.

Tested on Windows 10 21H2 (Build 19044) and Win 11 (Build 22000). 