### PR TITLE
Pre-emptive fix for VirtualDesktop.name on win11

### DIFF
--- a/pyvda/__init__.py
+++ b/pyvda/__init__.py
@@ -34,7 +34,7 @@ Example
     AppView.current().pin()
 """
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 import platform
 import os

--- a/pyvda/com_defns.py
+++ b/pyvda/com_defns.py
@@ -172,10 +172,19 @@ else:
 # In registry: Computer\HKEY_LOCAL_MACHINE\SOFTWARE\Classes\Interface\{FF72FFDD-BE7E-43FC-9C03-AD81681E88E4}
 class IVirtualDesktop(IUnknown):
     _iid_ = GUID_IVirtualDesktop
-    _methods_ = [
-        STDMETHOD(HRESULT, "IsViewVisible", (POINTER(IApplicationView), POINTER(UINT))),
-        COMMETHOD([], HRESULT, "GetID", (["out"], POINTER(GUID), "pGuid"),),
-    ]
+    if BUILD_OVER_21313:
+        _methods_ = [
+            STDMETHOD(HRESULT, "IsViewVisible", (POINTER(IApplicationView), POINTER(UINT))),
+            COMMETHOD([], HRESULT, "GetID", (["out"], POINTER(GUID), "pGuid"),),
+            COMMETHOD([], HRESULT, "Unknown", (["out"], POINTER(HWND), "pW"),),
+            COMMETHOD([], HRESULT, "GetName", (["out"], POINTER(HSTRING), "pName"),),
+            COMMETHOD([], HRESULT, "GetWallpaperPath", (["out"], POINTER(HSTRING), "pPath"),),
+        ]
+    else:
+        _methods_ = [
+            STDMETHOD(HRESULT, "IsViewVisible", (POINTER(IApplicationView), POINTER(UINT))),
+            COMMETHOD([], HRESULT, "GetID", (["out"], POINTER(GUID), "pGuid"),),
+        ]
 
 
 GUID_IVirtualDesktop2 = GUID("{31EBDE3F-6EC3-4CBD-B9FB-0EF6D09B41F4}")

--- a/pyvda/pyvda.py
+++ b/pyvda/pyvda.py
@@ -344,6 +344,9 @@ class VirtualDesktop():
         Returns:
             str: The desktop name.
         """
+        if BUILD_OVER_21313:
+            return str(self._virtual_desktop.GetName())
+
         array = self._manager_internal.GetDesktops(*NULL_IF_OVER_20231)
         for vd in array.iter(IVirtualDesktop2):
             if self.id == vd.GetID():


### PR DESCRIPTION
It looks like `IVirtualDesktopManagerInternal2` and `IVirtualDesktop2` were just a bodge to back-port desktop name support to windows 10. 