### PR TITLE
Mitigate the fact that Python 3.12 started to report platform.release…

### DIFF
--- a/pyvda/__init__.py
+++ b/pyvda/__init__.py
@@ -34,15 +34,22 @@ Example
     AppView.current().pin()
 """
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 import platform
 import os
 
+def _check_release():
+    try:
+        release = int(platform.release())
+        return release >= 10
+    except ValueError:
+        return platform.release() == "10"
+
 def _check_version():
-    if platform.system() != "Windows" or platform.release() != "10":
+    if platform.system() != "Windows" or not _check_release():
         raise WindowsError(
-            "The virtual desktop feature is only available on Windows 10"
+            "The virtual desktop feature is only available on Windows 10 and later."
         )
 
 if not os.getenv("READTHEDOCS"):


### PR DESCRIPTION
The package stopped working after upgrading to latest Python 3.12. The issue is that apparently **platform.release()** started reporting correctly the Windows release version.

The difference between 3.11 and 3.12 Python is below:

- **3.11:**

```python
Python 3.11.6 (tags/v3.11.6:8b6ee5b, Oct  2 2023, 14:57:12) [MSC v.1935 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import platform
>>> print(f'{platform.platform()} release {platform.release()} version {platform.version()}')
Windows-10-10.0.22000-SP0 release 10 version 10.0.22000
>>>
```

- **3.12:**

```python
Python 3.12.0 (tags/v3.12.0:0fb18b0, Oct  2 2023, 13:03:39) [MSC v.1935 64 bit (AMD64)] on win32
>>> import platform
>>> print(f'{platform.platform()} release {platform.release()} version {platform.version()}')
Windows-11-10.0.22000-SP0 release 11 version 10.0.22000
>>>
```

Example stack trace from the error under Python 3.12:

```
Traceback (most recent call last):
  File "D:\projects\wndscripts\shortcuts_app.py", line 8, in <module>
    import wnd_utils
  File "D:\projects\wndscripts\wnd_utils.py", line 21, in <module>
    from pyvda import AppView, get_apps_by_z_order, VirtualDesktop, get_virtual_desktops
  File "C:\Users\Miki\AppData\Local\Programs\Python\Python312\Lib\site-packages\pyvda\__init__.py", line 49, in <module>
    _check_version()
  File "C:\Users\Miki\AppData\Local\Programs\Python\Python312\Lib\site-packages\pyvda\__init__.py", line 44, in _check_version
    raise WindowsError(
OSError: The virtual desktop feature is only available on Windows 10
```

I've created this patch to try and parse the release to int, and check if version is equal or greater than 10. If parsing fails it uses the old logic, of just comparing the strings for equality.