### PR TITLE
`test_create_and_remove_desktop`: Revert original focus

### DIFF
--- a/tests/test_desktop_functions.py
+++ b/tests/test_desktop_functions.py
@@ -95,6 +95,7 @@ def test_create_and_remove_desktop():
 
     time.sleep(1) # Got to wait for the animation before we can return
     current_desktop.go()
+    current_window.set_focus()
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
When using `current_desktop.go()`, in 18363, the focus is not restored to the original window

Signed-off-by: Stavros Ntentos <133706+stdedos@users.noreply.github.com>